### PR TITLE
feat(frontend): unify date convention + priority picker (P5 #18, P6)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -16,18 +16,17 @@ on any fix plan before coding (standing memory).
 ## Protected / risky files — touch only inside their own phase, smoke-test manually
 
 - `frontend/src/Config/axiosConfig.js`
-- `frontend/src/redux/taskSlice.jsx` — open bugs P1#1, P4#2, P4#3, BL#7
+- `frontend/src/redux/taskSlice.jsx` — open bugs P4#2 (deferred), BL#7 (P1#1, P4#3 done)
 - `frontend/src/components/pages/hooks/usePopup.jsx` — **has uncommitted changes**; bugs P3#14, BL#20
-- `frontend/src/components/pages/create/CreateTask.jsx` — bugs P1#11, P5#18, BL#19, BL#20
+- `frontend/src/components/pages/create/CreateTask.jsx` — bugs BL#19, BL#20 (P1#11, P5#18, P6 done)
 - `server/modules/task/service.js` — no integration tests (see `server/backend.md` §Risk Register)
 
 ## Intersections (why the order below is what it is)
 
-1. **Priority picker (P6)** lands in `CreateTask.jsx` + `taskDetail.jsx` — the *same protected files* as
-   P1#11, P1#15, P5#18, BL#19. Fold the picker into those phases so protected files are opened once.
-2. **Date bug P5#18** spans both `CreateTask.jsx` and `taskDetail.jsx`.
-3. **P3#14 / P3#16** need caller tracing (`/diagnose`) before any edit — do not guess-fix.
-4. Backend P0 is fully isolated — no frontend coupling, can run anytime.
+1. ~~Priority picker (P6) + date bug P5#18 share `CreateTask.jsx`/`taskDetail.jsx`~~ — **done together
+   2026-06-06** (see Archive). Remaining `CreateTask.jsx` items: BL#19, BL#20.
+2. **P3#14 / P3#16** need caller tracing (`/diagnose`) before any edit — do not guess-fix.
+3. Backend P0 is fully isolated — no frontend coupling, can run anytime.
 
 ---
 
@@ -44,16 +43,25 @@ on any fix plan before coding (standing memory).
 
 ## P4 — Frontend · taskSlice mutation thunks *(protected)*
 
-- **#2** `taskSlice.jsx:121-167` — `updatedTask`, `completedTask`, `removedTask`, `removedAllTask`, `removedCategory` have no try/catch, no `rejectWithValue`, no `.rejected` handler → silent failures, `error` never set.
-- **#3** `taskSlice.jsx:179-186` — `setFormTask` does `new Date(startDate).toISOString()` guarded only on `undefined`; `null`→epoch 1970, invalid string→`RangeError` crashes reducer.
+- **#2 — DEFERRED** (depends on the error-UI decision, see below). `taskSlice.jsx:121-167` —
+  `updatedTask`, `completedTask`, `removedTask`, `removedAllTask`, `removedCategory` have no
+  try/catch, no `rejectWithValue`, no `.rejected` handler → silent failures, `error` never set.
+  **Scrutiny (2026-06-06):** the fix would write `state.task.error`, but **no component reads it**
+  (grepped every `useSelector`) — same dead-state as **#21**, and all four call-site catch blocks
+  already just `console.error(...)` without reading `.message`. So the fix is store-correctness only,
+  zero user-facing change. **Bundle with #21**: settle the error/loading UI surface (toast/banner)
+  first so `error` has a consumer, then wire `rejectWithValue` + `.rejected` with a real destination.
+- **#3** — DONE ✅ (2026-06-06, see Archive). Reachable `null`→1970 bug confirmed at the call site.
 
-## P5 — Frontend · date handling (needs `/verify` screenshots @ 390/768/1280)
+## P5 — Frontend · date handling — DONE ✅ (see Archive)
 
-- **#18** `CreateTask.jsx:81,85` hand-shift TZ offset before `toISOString()`; `taskDetail.jsx:97` does **not** → wrong-day bugs around DST/non-zero offsets. Unify the two paths.
+- **#18** — DONE ✅ (2026-06-06). Unified both paths on the local-instant convention via shared
+  `toDayISO`. Runtime `/verify` screenshots @ 390/768/1280 still pending.
 
-## P6 — Feature · priority picker UI (backend ready)
+## P6 — Feature · priority picker UI — DONE ✅ (see Archive)
 
-Backend fully supports `priority` (low|med|high; create defaults `low`). No picker shipped yet — users still can't set priority. Add a selector in `CreateTask.jsx` + `taskDetail.jsx` wired to the `priority` field. **Fold into P1/P5** (same protected files).
+Shipped a native-`<select>` `PriorityField` in `CreateTask.jsx` + `taskDetail.jsx`. Runtime `/verify`
+(persist on create, autosave on edit) still pending.
 
 ## Backlog — quality / lower severity (frontend audit)
 
@@ -66,7 +74,19 @@ Backend fully supports `priority` (low|med|high; create defaults `low`). No pick
 - **#17** `taskDetail.jsx:49-53` — sync effect guards on `isUpdating` but omits it from deps → stale closure can clobber in-progress edits.
 - **#19** `CreateTask.jsx:41-43` *(protected)* — `validator` dispatches `startDate` then reads it stale same-render; redundant (line 107 has `||` fallback).
 - **#20** Magic `setTimeout` sequencing for summary refetch: `usePopup.jsx:78` (100ms), `CreateTask.jsx:113` (300ms). Should await directly.
-- **#23** `taskDetail.jsx:25` *(protected)* — `debouncedUpdateTask = useRef(debounce(...))` but every call site uses it **without `.current`** (lines 58 `.flush()`, 82/100/127/153/179). A `useRef` returns `{current}`, so these call the ref object — that debounce/flush path is broken/dead, not a working reference. **Correction:** the old P2 #13 note ("TaskDetail does it right") was wrong. Surfaced by `/scrutinize` during P2. Fold into a P4-style protected-file phase; trace whether autosave actually fires before "fixing".
+- **#23 — CLOSED ✅ (stale, not a bug).** 2026-06-06 `/scrutinize` during P5/P6 re-traced
+  `taskDetail.jsx:25-47`: the `useRef(...)` **ends with `.current`** (line 47), so `debouncedUpdateTask`
+  IS the debounced function and every call site (`.flush()` line 58; `debouncedUpdateTask(...)` at
+  82/100/127/153/179) is correct. The autosave path works. The earlier "called without `.current`"
+  note (and the P2 #13 self-correction) predate the `.current` now present in the file — nothing to fix.
+
+- **#24** `StartDatePicker` defaults its empty `selected` to `new Date()` (with current time) while
+  `DeadlinePicker` defaults to `null`. So a freshly-picked **startDate stores `<day>T<now-time>Z`**
+  (e.g. `2026-07-10T13:44:10Z`) whereas a picked deadline stores clean local-midnight
+  (`...T17:00:00Z`). Surfaced by the P5 #18 `/verify` run (2026-06-06). The calendar **day** round-trips
+  correctly either way (P5 #18 holds), so this is low severity — just a time-component inconsistency
+  between the two fields. Fix: normalize startDate to local midnight (or default the picker's empty
+  `selected` to `null` like DeadlinePicker). Lives in `CreateTask.jsx` (*protected*).
 
 ### Findings from runtime verify session (2026-06-06, Playwright guest mode)
 
@@ -74,6 +94,7 @@ Backend fully supports `priority` (low|med|high; create defaults `low`). No pick
   P1 #1 fix) but **no component renders it** — only `state.user.loading` is consumed (`AuthForm.jsx`). It's
   dead UI state today. Either wire a task-loading spinner (the create/fetch flows have nothing) or strip the
   flag. Decide before adding more `loading` bookkeeping. *(Surfaced verifying #1 — its "stuck spinner" had no UI.)*
+  **Bundle P4 #2 here:** `state.task.error` is the same dead read-side — decide one error/loading UI surface for both.
 - **#22** Cleanup: one orphan guest task `PASS-create-*` left in **dev** Atlas from the verify run (guest cookie
   gone, so not deletable via UI). Harmless; drop it next time you're in dev Atlas.
 - **Parked (from P0):** prod Atlas `slimelist` is completely empty. If real prod users/tasks were ever expected,
@@ -87,6 +108,37 @@ Most of `components/pages/ui/`, `animation/`, `user/` (`Home`, `AllTask`, `Upcom
 ---
 
 ## Archive — closed work (rationale kept for reference)
+
+### P5 #18 + P6 — date unification + priority picker — DONE (2026-06-06, code + unit tests)
+Bundled because both land in the same protected files (`CreateTask.jsx`, `taskDetail.jsx`). Full
+detail in `frontend/MIGRATION.md`. **Runtime `/verify` @ 390/768/1280 still outstanding.**
+- **#18 (date):** root cause was *divergence* — `CreateTask` hand-shifted the TZ offset (stored
+  UTC-midnight of the picked day), `taskDetail` did raw `toISOString()` (local-midnight instant) → a
+  task created then edited could jump a calendar day. Decision (user): **local-instant / raw ISO** —
+  both pickers read back with `new Date(value)` in local time, so the raw instant round-trips to the
+  same calendar day in the user's TZ for any offset. Extracted `toDayISO` (`functions/date.js`); both
+  `handleDateChange` paths use it; CreateTask's offset math deleted. `toIsoDate` reducer guard (P4#3)
+  left alone (separate concern).
+- **#6 (picker):** `PriorityField` = styled **native `<select>`** (low|medium|high) — chosen over
+  cloning `CategoryTagField`'s custom dropdown (that's for a *dynamic* list; priority is a fixed enum).
+  No new wiring: `setFormTask` `...rest` carries it on create; the existing debounced `updatedTask` PUT
+  carries it on edit; backend defaults `updateData.priority || existing.priority || "low"`.
+- **Tests:** 78/78 (was 71; +4 date, +3 priority). **Lint:** only `PriorityField.jsx` adds entries,
+  all in the baseline `React`-unused + `prop-types` classes shared by every sibling.
+- **Cron note (verify):** raw ISO shifts the stored deadline instant by ~the TZ offset; the overdue
+  cron compares instants — confirm a task due "tomorrow" isn't prematurely failed.
+
+### P4 #3 — `setFormTask` unsafe date coercion — DONE (2026-06-06, `/scrutinize`)
+`setFormTask` guarded `new Date(value).toISOString()` only against `undefined`. Scrutiny traced the
+call site and found the bug is **reachable**: `CreateTask.jsx:87` dispatches
+`setFormTask({ deadline: null })` when the user clears the deadline → `new Date(null)` = epoch 0 →
+deadline silently became `"1970-01-01T00:00:00.000Z"` instead of `null`. The invalid-string→`RangeError`
+reducer crash was latent (every current caller passes `.toISOString()` output or `null`) but real.
+Fix: extracted `toIsoDate(value, fallback)` — `undefined`→keep current, `null`→stay null, invalid→keep
+current (no throw), valid→ISO. Used for both `startDate` and `deadline`. Added 2 regression tests
+(clear→null; invalid→no-throw + prior value kept). **71/71 Vitest** (was 69), no new lint
+(`taskSlice.jsx` + test file lint-clean; the 490 baseline errors are the pre-existing project-wide
+`React`-unused set). **P4 #2 deferred** — see open P4 / #21 (dead `state.task.error`).
 
 ### P3 #16 — `useFetchTask` refetch dep + dead `filterKey` — DONE (2026-06-06, `/diagnose`)
 **No live loop** — diagnosis: `fetchTasks.fulfilled` (`taskSlice.jsx:271-274`) doesn't bump

--- a/frontend/MIGRATION.md
+++ b/frontend/MIGRATION.md
@@ -312,3 +312,62 @@ Concern: LOGIC + one small VISUAL element (the button). Pure deletion, no new be
 - **Scrutinize finding (logged to BACKLOG, not P2)**: `taskDetail.jsx:25` uses
   `useRef(debounce(...))` but calls it without `.current` (lines 58/82/100…) — that
   debounce path is broken/dead. Do NOT copy it as the reference idiom.
+
+---
+
+## P4 #3 — `setFormTask` safe date coercion ✅ (2026-06-06, `/scrutinize`)
+
+- **File**: `src/redux/taskSlice.jsx` (protected) + `src/__tests__/redux/taskSlice.test.js`
+- **Test**: `npm test` (71/71, 9 files; was 69) + `npx eslint` on both touched files (clean)
+- **Bug**: `setFormTask` guarded `new Date(value).toISOString()` only on `undefined`. Scrutiny
+  traced the call site: `CreateTask.jsx:87` dispatches `setFormTask({ deadline: null })` when the
+  user clears a deadline → `new Date(null)` = epoch 0 → deadline silently became `1970-01-01`
+  instead of `null`. Invalid-string → `RangeError` reducer crash was latent (all current callers
+  pass `.toISOString()` output or `null`) but real.
+- **Fix**: extracted `toIsoDate(value, fallback)` — `undefined`→keep current · `null`→stay null ·
+  invalid→keep current (no throw) · valid→ISO. Applied to both `startDate` and `deadline`.
+- **Tests added**: clear deadline → `null` (not 1970); invalid date → no throw + prior value kept.
+- **P4 #2 deferred** (not done): would write `state.task.error`, which **no component reads**
+  (same dead-state as runtime-verify #21); all call-site catch blocks already `console.error`
+  without reading `.message`. Bundle with the #21 error/loading-UI decision. See BACKLOG.
+- **Lint**: the 490 baseline errors are the pre-existing project-wide set (`React`/`StrictMode`
+  unused, `userSlice` warnings); the two files touched here are lint-clean.
+
+---
+
+## P5 #18 + P6 — date unification + priority picker ✅ (2026-06-06, code + unit tests; runtime `/verify` pending)
+
+- **Files**: `src/functions/date.js` (new), `src/components/pages/ui/PriorityField.jsx` (new),
+  `src/components/pages/create/CreateTask.jsx` (protected), `src/components/pages/ui/taskDetail.jsx`
+  (protected); tests `src/__tests__/functions/date.test.js`, `src/__tests__/components/PriorityField.test.jsx` (both new).
+- **Test**: `npm test` → **78/78, 11 files** (was 71; +4 date, +3 priority).
+- **P5 #18 — date convention unified (decision: local-instant / raw ISO).** Root cause was
+  *divergence*: `CreateTask` hand-shifted the TZ offset (stored UTC-midnight of the picked day) while
+  `taskDetail` did raw `toISOString()` (stored the local-midnight instant) → a task created then
+  edited could jump a calendar day. Both pickers read back with `new Date(value)` in local time, so
+  the raw ISO instant round-trips to the same calendar day in the user's own TZ for any offset.
+  Extracted `toDayISO(date)` (`functions/date.js`, null/invalid → `null`); both `handleDateChange`
+  paths now call it. CreateTask's offset math deleted. `taskSlice` `toIsoDate` (reducer guard, P4#3)
+  is a separate concern and untouched.
+- **P6 — priority picker shipped.** New `PriorityField` = styled **native `<select>`** (low|medium|high,
+  values match backend `PRIORITIES`); chosen over cloning `CategoryTagField`'s custom dropdown because
+  priority is a fixed enum and a native control is accessible by default and emits a real
+  `{target:{name,value}}` event. Rendered in the category/date row of both files. **No new wiring**:
+  `setFormTask` spreads `...rest` so create persists `priority` (already sent at `handleSubmit`); on
+  taskDetail the existing `handleInputChange`→`debouncedUpdateTask`→`updatedTask` PUT carries it, and
+  backend `updateTask` defaults `updateData.priority || existing.priority || "low"`.
+- **BL #23 correction**: this session's `/scrutinize` traced `taskDetail.jsx:25-47` — the `useRef(...)`
+  ends with **`.current`**, so `debouncedUpdateTask` is the debounced *function* and all call sites
+  (incl. `.flush()`) are correct. The autosave path is **not** broken; the old "called without
+  `.current`" note (BACKLOG BL #23 / P2 scrutinize log above) is stale and should be closed.
+- **Lint**: only `PriorityField.jsx` adds entries, all in the two pre-existing baseline classes
+  (`React`-unused + `react/prop-types` missing) shared by every sibling component; `date.js` and both
+  test files are lint-clean. No prop-types added to PriorityField to stay consistent with the codebase
+  (which uses none).
+- **Backend interaction (verify at runtime)**: raw-ISO moves the stored deadline instant by ~the TZ
+  offset; the overdue cron (`cronJob.js:19-20`) compares instants, so confirm a task due "tomorrow"
+  isn't prematurely failed. Out of scope: the cron already marks tasks overdue from the *start* of the
+  due day (separate latent item).
+- **Outstanding**: runtime `/verify` (guest mode, Playwright @ 390/768/1280) — create+edit date
+  round-trips to same day; priority persists on create and autosaves on edit (network shows `PUT` with
+  `priority`).

--- a/frontend/src/__tests__/components/PriorityField.test.jsx
+++ b/frontend/src/__tests__/components/PriorityField.test.jsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import PriorityField from "../../components/pages/ui/PriorityField";
+
+describe("PriorityField", () => {
+  it("renders the three priority options", () => {
+    render(<PriorityField value="low" handleInputChange={() => {}} />);
+    const opts = screen.getAllByRole("option").map((o) => o.value);
+    expect(opts).toEqual(["low", "medium", "high"]);
+  });
+
+  it("reflects the current value", () => {
+    render(<PriorityField value="high" handleInputChange={() => {}} />);
+    expect(screen.getByRole("combobox").value).toBe("high");
+  });
+
+  it("emits a name/value change event the parent handlers consume", () => {
+    // Capture synchronously: the <select> is controlled, so after the handler
+    // returns React reverts the DOM node's value to the `value` prop.
+    let captured;
+    const handleInputChange = vi.fn((e) => {
+      captured = { name: e.target.name, value: e.target.value };
+    });
+    render(
+      <PriorityField
+        name="priority"
+        value="low"
+        handleInputChange={handleInputChange}
+      />
+    );
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "medium" },
+    });
+    expect(handleInputChange).toHaveBeenCalledTimes(1);
+    expect(captured).toEqual({ name: "priority", value: "medium" });
+  });
+});

--- a/frontend/src/__tests__/functions/date.test.js
+++ b/frontend/src/__tests__/functions/date.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { toDayISO } from "../../functions/date";
+
+describe("toDayISO", () => {
+  it("serializes a valid Date to its ISO instant", () => {
+    const d = new Date("2026-06-10T00:00:00.000Z");
+    expect(toDayISO(d)).toBe("2026-06-10T00:00:00.000Z");
+  });
+
+  it("returns null for null / undefined (cleared field)", () => {
+    expect(toDayISO(null)).toBeNull();
+    expect(toDayISO(undefined)).toBeNull();
+  });
+
+  it("returns null for an invalid Date instead of throwing", () => {
+    expect(toDayISO(new Date("not-a-date"))).toBeNull();
+  });
+
+  it("round-trips a local-midnight Date back to the same calendar day", () => {
+    // Picker emits local midnight; new Date(iso) reads back in local time.
+    const picked = new Date(2026, 5, 10); // 10 Jun, local midnight
+    const back = new Date(toDayISO(picked));
+    expect(back.getFullYear()).toBe(2026);
+    expect(back.getMonth()).toBe(5);
+    expect(back.getDate()).toBe(10);
+  });
+});

--- a/frontend/src/components/pages/create/CreateTask.jsx
+++ b/frontend/src/components/pages/create/CreateTask.jsx
@@ -12,9 +12,11 @@ import InputField from "../ui/inputField";
 import DeadlinePicker from "../ui/DeadlinePicker";
 import StartDatePicker from "../ui/StartDatePicker";
 import CategoryTagField from "../ui/CategoryTagField";
+import PriorityField from "../ui/PriorityField";
 import ProgressField from "../ui/ProgressField";
 import Tooltip from "../ui/Tooltip";
 import FadeUpContainer from "../animation/FadeUpContainer";
+import { toDayISO } from "../../../functions/date";
 import {
   fetchSummary,
   fetchSummaryByCategory,
@@ -76,16 +78,9 @@ function CreateTask({ onClose }) {
 
   const handleDateChange = (date, field) => {
     if (field === "startDate") {
-      const selectedDate = date ? date : new Date();
-      const formatDate = new Date(selectedDate.getTime() - (selectedDate.getTimezoneOffset() * 60000));
-      dispatch(setFormTask({ [field]: formatDate.toISOString() }));
+      dispatch(setFormTask({ startDate: toDayISO(date) ?? new Date().toISOString() }));
     } else if (field === "deadline") {
-      if (date) {
-        const formatDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
-        dispatch(setFormTask({ [field]: formatDate.toISOString() }));
-      } else {
-        dispatch(setFormTask({ [field]: null }));
-      }
+      dispatch(setFormTask({ deadline: toDayISO(date) }));
     }
   };
 
@@ -201,6 +196,11 @@ function CreateTask({ onClose }) {
                 }
                 onChange={(date) => handleDateChange(date, "deadline")}
                 placeholder="DEADLINE"
+              />
+              <PriorityField
+                name="priority"
+                value={formTask.priority || "low"}
+                handleInputChange={handleInputChange}
               />
             </div>
 

--- a/frontend/src/components/pages/ui/PriorityField.jsx
+++ b/frontend/src/components/pages/ui/PriorityField.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faFlag, faChevronDown } from "@fortawesome/free-solid-svg-icons";
+
+// Fixed enum — values must match the backend PRIORITIES (low|medium|high).
+const PRIORITY_OPTIONS = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+];
+
+// Native <select> (not the CategoryTagField custom dropdown): priority is a fixed
+// 3-value enum, so a native control is accessible by default and emits a real
+// { target: { name, value } } event that the parents' handleInputChange already consumes.
+function PriorityField({ name = "priority", value = "low", handleInputChange }) {
+  return (
+    <div className="relative md:w-[230px] w-full">
+      <select
+        name={name}
+        value={value || "low"}
+        onChange={handleInputChange}
+        className="md:w-[230px] w-full h-[44px] cursor-pointer appearance-none text-xl shadow border-[2px] border-purpleNormal bg-transparent rounded-xl p-2 pl-14 pr-10 text-purpleNormal leading-tight focus:outline-none focus:ring-2 focus:ring-purpleNormal focus:ring-opacity-50"
+        aria-label="Priority"
+      >
+        {PRIORITY_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value} className="text-black">
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      <FontAwesomeIcon
+        icon={faFlag}
+        className="text-purpleNormal text-xl left-5 bottom-3 absolute pointer-events-none"
+        aria-hidden="true"
+      />
+      <FontAwesomeIcon
+        icon={faChevronDown}
+        className="text-purpleNormal text-base right-4 bottom-4 absolute pointer-events-none"
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+export default PriorityField;

--- a/frontend/src/components/pages/ui/taskDetail.jsx
+++ b/frontend/src/components/pages/ui/taskDetail.jsx
@@ -4,7 +4,9 @@ import StartDatePicker from "./StartDatePicker";
 import DeadlinePicker from "./DeadlinePicker";
 import ProgressField from "./ProgressField";
 import CategoryTagField from "./CategoryTagField";
+import PriorityField from "./PriorityField";
 import { updatedTask } from "../../../redux/taskSlice";
+import { toDayISO } from "../../../functions/date";
 import { debounce } from "lodash";
 import { useDispatch, useSelector } from "react-redux";
 import FadeUpContainer from "../animation/FadeUpContainer";
@@ -93,9 +95,8 @@ function TaskDetail({ onClose }) {
   const handleDateChange = useCallback(
     (date, field) => {
       setEditedTask((prevTask) => {
-        // แปลง date เป็น string เพื่อเก็บใน redux
-        const formattedDate = date instanceof Date ? date.toISOString() : date;
-        const updatedTask = { ...prevTask, [field]: formattedDate };
+        // แปลง date เป็น string เพื่อเก็บใน redux (shared helper — see P5 #18)
+        const updatedTask = { ...prevTask, [field]: toDayISO(date) };
 
         debouncedUpdateTask(updatedTask);
         return updatedTask;
@@ -235,6 +236,11 @@ function TaskDetail({ onClose }) {
               selected={editedTask.deadline}
               onChange={(date) => handleDateChange(date, "deadline")}
               placeholder="DEADLINE"
+            />
+            <PriorityField
+              name="priority"
+              value={editedTask.priority || "low"}
+              handleInputChange={handleInputChange}
             />
           </div>
           <textarea

--- a/frontend/src/functions/date.js
+++ b/frontend/src/functions/date.js
@@ -1,0 +1,7 @@
+// Shared date-only serializer for task forms.
+// The date pickers emit a Date at LOCAL midnight of the picked day, and read back
+// with `new Date(value)` in local time — so storing the raw ISO instant round-trips
+// to the same calendar day in the user's own timezone. Keep CreateTask and taskDetail
+// on this one helper so the two paths can't diverge (the root cause of P5 #18).
+export const toDayISO = (date) =>
+  date instanceof Date && !isNaN(date) ? date.toISOString() : null;


### PR DESCRIPTION
@
## What

Bundled because both items land in the same protected files (`CreateTask.jsx`, `taskDetail.jsx`).

### P5 #18 — date convention unified
The two date-write paths disagreed: `CreateTask` hand-shifted the TZ offset (stored UTC-midnight of the picked day) while `taskDetail` did raw `toISOString()` (local-midnight instant) → a task created then edited could **jump a calendar day**. Now both go through one shared helper `functions/date.js` → `toDayISO`, on the **local-instant** convention. Both pickers read back with `new Date(value)` in local time, so the raw instant round-trips to the same calendar day in the users own timezone for any offset. CreateTasks offset math removed.

### P6 — priority picker
New `PriorityField` = styled **native `<select>`** (low|medium|high) in both files. Chosen over cloning `CategoryTagField`s custom dropdown (that exists for a *dynamic* list; priority is a fixed enum). No new wiring: `setFormTask` spreads `...rest` on create; the existing debounced `updatedTask` PUT carries it on edit; backend defaults `updateData.priority || existing.priority || "low"`.

## Tests
- **78/78 Vitest** (was 71; +4 date helper, +3 priority picker).
- Lint: only `PriorityField.jsx` adds entries, all in the pre-existing `React`-unused + `prop-types` baseline classes (codebase uses no prop-types — left consistent).

## Runtime verification (Playwright, guest mode, 390/768/1280)
- Create task with start 10/07 + deadline 20/07 → reopen in detail → **dates identical** (round-trip holds).
- Priority **persists on create** (POST `priority:"high"`) and **autosaves on edit** (PUT `priority:"low"`).

## Also
- **Closes BL #23 as stale** — traced `taskDetail.jsx:25-47`: the `useRef(...)` already ends with `.current`, so the debounced autosave fn + call sites are correct (confirmed by the PUT firing at runtime). Not a bug.
- Logged new **BL #24** (low sev): `startDate` carries current time-of-day while `deadline` stores clean midnight, due to the two pickers different empty-state defaults. Day round-trips fine; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@