### PR TITLE
fix(server): grace overdue cron by one UTC day for raw-ISO deadlines (P0 #25)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -30,6 +30,32 @@ on any fix plan before coding (standing memory).
 
 ---
 
+## P0 — Backend · overdue cron fails east-of-UTC tasks one day early — DONE ✅ (branch `fix/backend-p0-25-overdue-cron-tz`)
+
+**#25 — FIXED 2026-06-06.** Added `overdueThreshold`/`isOverdue` (pure, UTC-anchored, 1-day grace) to
+`shared/utils/deadlineUtils.js`; `cronJob.js` query now `deadline: { $lt: overdueThreshold() }`. 24h grace
+> 14h max TZ skew → **never fails any zone early** (verified +14 / −12 extremes); cost is east/UTC linger
+~1 cron cycle (benign). Kept P5#18 as-is (user's call). No DB integration seam existed for the cron — the
+fix is the seam: pure-function unit tests (`test/utils/deadlineUtils.test.js`, +5, **36/36 Jest**). Original
+repro confirmed flipped (first fire `true→false`). Earlier detail below for reference:
+
+**#25** `server/job/cronJob.js:15-33` `updateOverdueTasks`. **This is the cron interaction the P5#18
+verify parked (was line 128).** Verified FAIL at runtime (TZ+7, the dev's own zone): P5#18's raw
+local-instant convention pushes east-of-UTC deadlines *back* across the UTC-midnight line, so the
+cron's strict `deadline: { $lt: currentDate }` — running **in UTC on Render**, `0 0 * * *` — marks
+them `failed` **one full cron cycle (one calendar day) early**.
+
+- **Evidence:** "due tomorrow (Jun 7)" picked in +7 → `toDayISO` stores `2026-06-06T17:00:00Z`. First
+  fire `2026-06-07T00:00:00Z`: `17:00Z Jun 6 < 00:00Z Jun 7` → **failed at 07:00 Jun 7 Bangkok, the
+  morning of the day it's due.** Pre-change storage (`2026-06-07T00:00:00Z`) survived to the next cycle.
+- **Asymmetric:** positive (east) offsets regress; west-of-UTC unaffected (local midnight lands *after*
+  UTC midnight). Live in prod — `server.js:52` calls `checkOverdueTasks()` at startup.
+- **Two stacked layers:** (a) deadline stored as **start-of-day** midnight (pre-existing — even in pure
+  UTC a "due Jun 7" task is overdue the instant Jun 7 begins); (b) P5#18's raw instant activated (a) for
+  the most common real users. **Fix direction (not the revert):** cron should compare *calendar days* in
+  a defined zone, or normalize stored deadlines to end-of-day. Isolated to `cronJob.js` — no frontend
+  coupling. UI calendar-day round-trip is unaffected (P5#18's stated goal holds). Next: `/diagnose`.
+
 ## P1 — Frontend · critical logic bugs — ALL DONE ✅ (see Archive)
 
 ## P2 — Frontend · search field — DONE ✅ (see Archive)
@@ -125,8 +151,9 @@ detail in `frontend/MIGRATION.md`. **Runtime `/verify` @ 390/768/1280 still outs
   carries it on edit; backend defaults `updateData.priority || existing.priority || "low"`.
 - **Tests:** 78/78 (was 71; +4 date, +3 priority). **Lint:** only `PriorityField.jsx` adds entries,
   all in the baseline `React`-unused + `prop-types` classes shared by every sibling.
-- **Cron note (verify):** raw ISO shifts the stored deadline instant by ~the TZ offset; the overdue
-  cron compares instants — confirm a task due "tomorrow" isn't prematurely failed.
+- **Cron note (verify):** RESOLVED → **confirmed a real bug, see P0 #25.** Raw ISO shifts the stored
+  deadline instant by the TZ offset; the overdue cron compares instants in UTC and DOES prematurely fail
+  east-of-UTC tasks by one calendar day.
 
 ### P4 #3 — `setFormTask` unsafe date coercion — DONE (2026-06-06, `/scrutinize`)
 `setFormTask` guarded `new Date(value).toISOString()` only against `undefined`. Scrutiny traced the

--- a/server/job/cronJob.js
+++ b/server/job/cronJob.js
@@ -2,6 +2,7 @@ const cron = require("node-cron");
 const Tasks = require("../Models/Tasks");
 const User = require("../Models/User");
 const { startOfDay , subDays } = require("date-fns");
+const { overdueThreshold } = require("../shared/utils/deadlineUtils");
 
 const checkOverdueTasks = () => {
   cron.schedule("0 0 * * *", async () => {
@@ -13,11 +14,13 @@ const checkOverdueTasks = () => {
 
 // manual
 const updateOverdueTasks = async () => {
-  const currentDate = new Date();
+  // P0 #25: grace by one UTC day so raw local-instant deadlines (P5 #18) are not
+  // failed before the due day has ended in the user's own timezone. See overdueThreshold.
+  const cutoff = overdueThreshold();
 
   try {
     const overdueTasks = await Tasks.find({
-      deadline: { $lt: currentDate },
+      deadline: { $lt: cutoff },
       status: { $ne: "completed" },
     });
 

--- a/server/shared/utils/deadlineUtils.js
+++ b/server/shared/utils/deadlineUtils.js
@@ -45,4 +45,29 @@ const getTaskDeadlineRange = (deadline) => {
   if (isNextMonth) return "nextMonth";
 };
 
-module.exports = { getTaskDeadlineRange };
+/**
+ * Overdue threshold for the daily cron (P0 #25).
+ *
+ * Deadlines are stored as a raw local-instant (P5 #18 frontend convention), so a
+ * task the user set for "day D" lands at local-midnight(D) — anywhere within ±14h
+ * of UTC midnight depending on their timezone offset. The server has no per-user
+ * timezone, so it cannot recover which calendar day was meant from the bare instant.
+ *
+ * We therefore grace the comparison by one full day, anchored to UTC start-of-day
+ * (explicit UTC, not date-fns startOfDay, so behaviour is identical wherever the
+ * cron is deployed). 24h grace > the 14h max TZ skew, which guarantees we never
+ * mark a task failed BEFORE its due day has ended in any timezone — the only
+ * user-harmful direction. The cost is that some zones see a task linger as
+ * not-failed up to ~one extra cron cycle, which is benign for gamification.
+ */
+const overdueThreshold = (now = new Date()) => {
+  const t = new Date(now);
+  t.setUTCHours(0, 0, 0, 0);
+  t.setUTCDate(t.getUTCDate() - 1);
+  return t;
+};
+
+const isOverdue = (deadline, now = new Date()) =>
+  new Date(deadline) < overdueThreshold(now);
+
+module.exports = { getTaskDeadlineRange, overdueThreshold, isOverdue };

--- a/server/test/utils/deadlineUtils.test.js
+++ b/server/test/utils/deadlineUtils.test.js
@@ -1,5 +1,9 @@
 const { addDays, startOfWeek, addWeeks } = require("date-fns");
-const { getTaskDeadlineRange } = require("../../shared/utils/deadlineUtils");
+const {
+  getTaskDeadlineRange,
+  isOverdue,
+  overdueThreshold,
+} = require("../../shared/utils/deadlineUtils");
 
 describe("getTaskDeadlineRange", () => {
   it('returns "today" for today\'s date', () => {
@@ -25,5 +29,42 @@ describe("getTaskDeadlineRange", () => {
   it('returns undefined for a date with no matching bucket', () => {
     // A date far in the future (2 years out) falls outside all defined buckets
     expect(getTaskDeadlineRange(addDays(new Date(), 730))).toBeUndefined();
+  });
+});
+
+// Regression: P0 #25 — the overdue cron must not fail a task before the day it
+// was due has passed in the user's own timezone. The deadline is stored as a raw
+// local-instant (P5 #18), so a "due day D" pick lands anywhere within ±14h of UTC
+// midnight depending on the user's offset. A 1-day grace (UTC start-of-yesterday)
+// guarantees we never fail EARLY in any zone — the harmful direction. All instants
+// below are absolute UTC, so these assertions are deterministic on any host TZ.
+describe("isOverdue / overdueThreshold (P0 #25 cron TZ safety)", () => {
+  it("overdueThreshold is UTC start-of-yesterday relative to now", () => {
+    const now = new Date("2026-06-07T13:52:00.000Z");
+    expect(overdueThreshold(now).toISOString()).toBe("2026-06-06T00:00:00.000Z");
+  });
+
+  // +7 (the dev's zone): "due Jun 7" -> stored 2026-06-06T17:00:00Z
+  it("does NOT fail a +7 'due tomorrow' task at the first cron fire", () => {
+    const deadline = "2026-06-06T17:00:00.000Z";
+    expect(isOverdue(deadline, new Date("2026-06-07T00:00:00.000Z"))).toBe(false);
+  });
+  it("DOES fail the +7 task one cron cycle later", () => {
+    const deadline = "2026-06-06T17:00:00.000Z";
+    expect(isOverdue(deadline, new Date("2026-06-08T00:00:00.000Z"))).toBe(true);
+  });
+
+  // Extreme east (+14): "due Jun 7" -> stored 2026-06-06T10:00:00Z — still not early
+  it("never fails an extreme-east (+14) task early", () => {
+    const deadline = "2026-06-06T10:00:00.000Z";
+    expect(isOverdue(deadline, new Date("2026-06-07T00:00:00.000Z"))).toBe(false);
+    expect(isOverdue(deadline, new Date("2026-06-08T00:00:00.000Z"))).toBe(true);
+  });
+
+  // Extreme west (-12): "due Jun 7" -> stored 2026-06-07T12:00:00Z — lands exactly on time
+  it("fails an extreme-west (-12) task on the correct cycle, not early", () => {
+    const deadline = "2026-06-07T12:00:00.000Z";
+    expect(isOverdue(deadline, new Date("2026-06-08T00:00:00.000Z"))).toBe(false);
+    expect(isOverdue(deadline, new Date("2026-06-09T00:00:00.000Z"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem
P5 #18 stores task deadlines as a raw local-instant, so a "due day D" pick lands at local-midnight(D) — up to ±14h from UTC midnight depending on the user's offset. The overdue cron (`server/job/cronJob.js`, live in prod via `server.js:52`) ran `deadline $lt now` **in UTC with no per-user timezone**, so east-of-UTC tasks were marked `failed` a full cron cycle early.

**Verified live (TZ+7):** a task due "tomorrow (Jun 7)" stores `2026-06-06T17:00:00Z` and was failed at the first `00:00Z` fire — 07:00 Bangkok on the morning it was still due. The gamification "failed" status flips wrongly.

A bare instant only means the right calendar day *in the zone it was written*; the server can't recover that, so a naive "compare calendar days" approach doesn't fix it (`startOfDay(17:00Z Jun6)` in UTC is still Jun 6).

## Fix
Add pure, UTC-anchored `overdueThreshold`/`isOverdue` to `shared/utils/deadlineUtils.js` and switch the cron query to `deadline $lt overdueThreshold()` (start-of-yesterday, 1-day grace). 24h grace > the 14h max TZ skew ⇒ **no zone is ever failed early** (the only user-harmful direction). Cost: east/UTC tasks linger ~1 cron cycle as not-failed — benign for gamification. P5 #18 left untouched (deliberate, per decision).

Verified at the +14 and −12 extremes, not just +7.

## Tests
The cron had **no DB integration seam** — the extracted pure functions are the seam. +5 unit tests in `test/utils/deadlineUtils.test.js`. **36/36 Jest.** Original repro confirmed flipped (first fire `true → false`, second fire still `true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)