### PR TITLE
fix(frontend): safe date coercion in setFormTask reducer (P4 #3)

### DIFF
--- a/frontend/src/__tests__/redux/taskSlice.test.js
+++ b/frontend/src/__tests__/redux/taskSlice.test.js
@@ -105,6 +105,20 @@ describe("taskSlice — form & progress", () => {
     expect(typeof state.formTask.startDate).toBe("string");
     expect(state.formTask.startDate).toContain("2026-05-20");
   });
+  it("setFormTask(deadline: null) clears to null, not epoch 1970", () => {
+    const seeded = reducer(init(), setFormTask({ deadline: "2026-05-20" }));
+    const cleared = reducer(seeded, setFormTask({ deadline: null }));
+    expect(cleared.formTask.deadline).toBe(null);
+  });
+  it("setFormTask with an invalid date does not throw and keeps the prior value", () => {
+    const seeded = reducer(init(), setFormTask({ startDate: "2026-05-20" }));
+    const prior = seeded.formTask.startDate;
+    let next;
+    expect(() => {
+      next = reducer(seeded, setFormTask({ startDate: "not-a-date" }));
+    }).not.toThrow();
+    expect(next.formTask.startDate).toBe(prior);
+  });
   it("resetFormTask restores defaults", () => {
     const dirty = {
       ...init(),

--- a/frontend/src/redux/taskSlice.jsx
+++ b/frontend/src/redux/taskSlice.jsx
@@ -27,6 +27,16 @@ function writeStreakStatus(value) {
   }
 }
 
+// Safe date coercion for form fields. `undefined` = field absent → keep current;
+// `null` = explicit clear → stay null (was silently becoming 1970-01-01); an
+// invalid date keeps the current value instead of throwing RangeError in the reducer.
+function toIsoDate(value, fallback) {
+  if (value === undefined) return fallback;
+  if (value === null) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? fallback : d.toISOString();
+}
+
 const initialState = {
   tasks: [],
   searchResults: [],
@@ -176,14 +186,8 @@ const taskSlice = createSlice({
       state.formTask = {
         ...state.formTask,
         ...rest,
-        startDate:
-          startDate !== undefined
-            ? new Date(startDate).toISOString()
-            : state.formTask.startDate,
-        deadline:
-          deadline !== undefined
-            ? new Date(deadline).toISOString()
-            : state.formTask.deadline,
+        startDate: toIsoDate(startDate, state.formTask.startDate),
+        deadline: toIsoDate(deadline, state.formTask.deadline),
       };
       console.log("Updated formTask:", state.formTask);
     },


### PR DESCRIPTION
## Problem
`setFormTask` guarded `new Date(value).toISOString()` only against `undefined`. So clearing the deadline — `setFormTask({ deadline: null })` at `CreateTask.jsx:87` — ran `new Date(null)` = epoch 0 and silently stored `"1970-01-01T00:00:00.000Z"` instead of `null`. An invalid date string would also throw `RangeError` inside the reducer.

## Fix
Extract `toIsoDate(value, fallback)`: `undefined` → keep current, `null` → stay null, invalid → keep current (no throw), valid → ISO. Applied to both `startDate` and `deadline`.

## Tests
+2 regression tests (clear → null; invalid → no-throw + prior value kept). **32/32** in `taskSlice.test.js`.

Note: this was completed earlier but never committed — it sat uncommitted in the working tree. This PR lands it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)