### PR TITLE
feat(frontend): surface task mutation failures via error toast (#21, P4 #2)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -69,14 +69,16 @@ them `failed` **one full cron cycle (one calendar day) early**.
 
 ## P4 — Frontend · taskSlice mutation thunks *(protected)*
 
-- **#2 — DEFERRED** (depends on the error-UI decision, see below). `taskSlice.jsx:121-167` —
-  `updatedTask`, `completedTask`, `removedTask`, `removedAllTask`, `removedCategory` have no
-  try/catch, no `rejectWithValue`, no `.rejected` handler → silent failures, `error` never set.
-  **Scrutiny (2026-06-06):** the fix would write `state.task.error`, but **no component reads it**
-  (grepped every `useSelector`) — same dead-state as **#21**, and all four call-site catch blocks
-  already just `console.error(...)` without reading `.message`. So the fix is store-correctness only,
-  zero user-facing change. **Bundle with #21**: settle the error/loading UI surface (toast/banner)
-  first so `error` has a consumer, then wire `rejectWithValue` + `.rejected` with a real destination.
+- **#2 + #21 — DONE ✅ (2026-06-06, branch `fix/frontend-21-p4-2-task-error-toast`).** Decision (user):
+  minimal error toast, leave `loading` for later. `/scrutinize` reshaped the fix: the 5 thunks already
+  `.rejected` automatically (promise rejection — `rejectWithValue` not load-bearing), so instead of 10
+  edits to the protected slice, used **two matchers** — `isPending(...)` clears `state.error`,
+  `isRejected(...)` sets `error = payload ?? error.message ?? "Something went wrong"`. Clearing on pending
+  fixes the re-fire bug (identical repeat error still re-triggers). Added `clearTaskError` reducer + new
+  App-level `TaskErrorToast.jsx` (self-rolled, no dep, auto-dismiss 4s). **83/83 Vitest** (+5), lint clean.
+  **Outstanding:** runtime `/verify` (force a 500 on a PUT/DELETE, confirm toast renders + dismisses).
+  **Spun off → BL #26** (optimistic category-delete not rolled back on failure, surfaced in scrutiny).
+  `loading` (#21's other half) still dead — left as-is, decide if/when a spinner is wanted.
 - **#3** — DONE ✅ (2026-06-06, see Archive). Reachable `null`→1970 bug confirmed at the call site.
 
 ## P5 — Frontend · date handling — DONE ✅ (see Archive)
@@ -120,7 +122,11 @@ Shipped a native-`<select>` `PriorityField` in `CreateTask.jsx` + `taskDetail.js
   P1 #1 fix) but **no component renders it** — only `state.user.loading` is consumed (`AuthForm.jsx`). It's
   dead UI state today. Either wire a task-loading spinner (the create/fetch flows have nothing) or strip the
   flag. Decide before adding more `loading` bookkeeping. *(Surfaced verifying #1 — its "stuck spinner" had no UI.)*
-  **Bundle P4 #2 here:** `state.task.error` is the same dead read-side — decide one error/loading UI surface for both.
+  **Error half DONE** via P4 #2 toast (see P4 above); the `error` read-side now exists. `loading` still dead.
+- **#26** `usePopup.jsx:102` `handleRemovedItem` dispatches `removeCategories(id)` (optimistic UI removal)
+  *before* the awaited `removedCategory(id)`; the catch only `console.error`s — **no rollback**. With the new
+  P4 #2 toast, a failed category delete now shows an error *while the category has already vanished* from the
+  UI until refetch. Surfaced by `/scrutinize` (2026-06-06). Fix: re-insert on failure, or drop the optimism.
 - **#22** Cleanup: one orphan guest task `PASS-create-*` left in **dev** Atlas from the verify run (guest cookie
   gone, so not deletable via UI). Harmless; drop it next time you're in dev Atlas.
 - **Parked (from P0):** prod Atlas `slimelist` is completely empty. If real prod users/tasks were ever expected,

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -76,7 +76,14 @@ them `failed` **one full cron cycle (one calendar day) early**.
   `isRejected(...)` sets `error = payload ?? error.message ?? "Something went wrong"`. Clearing on pending
   fixes the re-fire bug (identical repeat error still re-triggers). Added `clearTaskError` reducer + new
   App-level `TaskErrorToast.jsx` (self-rolled, no dep, auto-dismiss 4s). **83/83 Vitest** (+5), lint clean.
-  **Outstanding:** runtime `/verify` (force a 500 on a PUT/DELETE, confirm toast renders + dismisses).
+  **Runtime `/verify` DONE ✅ (2026-06-06, Playwright guest mode, forced 500 on `PATCH /task/:id/completed`):**
+  toast renders bottom-right ("Request failed with status code 500"), auto-dismisses ~4.4s, identical repeat
+  error re-fires (pending-clears-error confirmed), manual × works. **But verify caught a shipped app-wide
+  crash:** the committed `TaskErrorToast.jsx` selected `state.task.error` (singular) while the store registers
+  the reducer under `tasks` (plural, `store.jsx:8`) → `undefined.error` threw on every render → no error
+  boundary → **whole app blank for all users**. The 5 unit tests missed it (reducer tested directly, never the
+  selector key). Fixed `state.task`→`state.tasks` (1 char). Lesson: consider an App-level error boundary so a
+  bad selector degrades instead of white-screening.
   **Spun off → BL #26** (optimistic category-delete not rolled back on failure, surfaced in scrutiny).
   `loading` (#21's other half) still dead — left as-is, decide if/when a spinner is wanted.
 - **#3** — DONE ✅ (2026-06-06, see Archive). Reachable `null`→1970 bug confirmed at the call site.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import MainLayout from "./components/MainLayout"; // Main application layout
 import AuthProvider from "./components/pages/authen/AuthProvider"; // Provides authentication context or logic
 import PublicRoute from "./components/pages/authen/PublicRoute"; // Component to restrict access for authenticated users
 import LoadingPage from "./components/pages/animation/LoadingPage";
+import TaskErrorToast from "./components/pages/ui/TaskErrorToast";
 
 // --- Lazy Loaded Components (Code Splitting) ---
 const Home = lazy(() => import("./components/pages/user/Home"));
@@ -30,6 +31,7 @@ function App() {
 
   return (
     <AuthProvider skip={isGuest}>
+      <TaskErrorToast />
       <BrowserRouter>
         <Suspense fallback={<LoadingPage />}>
           <Routes>

--- a/frontend/src/__tests__/redux/taskSlice.test.js
+++ b/frontend/src/__tests__/redux/taskSlice.test.js
@@ -11,6 +11,7 @@ import reducer, {
   setFormTask,
   resetFormTask,
   clearTask,
+  clearTaskError,
   clearSearchResults,
   addSteps,
   removeStep,
@@ -270,5 +271,40 @@ describe("taskSlice — async write lifecycle", () => {
       payload: "create failed",
     });
     expect(state.error).toBe("create failed");
+  });
+});
+
+describe("taskSlice — mutation error surface (#21 / P4 #2)", () => {
+  it("updatedTask.rejected records error from rejectWithValue payload", () => {
+    const state = reducer(init(), {
+      type: updatedTask.rejected.type,
+      payload: "save failed",
+      error: { message: "Rejected" },
+    });
+    expect(state.error).toBe("save failed");
+  });
+  it("falls back to error.message when there is no payload (uncaught throw)", () => {
+    const state = reducer(init(), {
+      type: completedTask.rejected.type,
+      error: { message: "Network Error" },
+    });
+    expect(state.error).toBe("Network Error");
+  });
+  it("falls back to a generic message when neither is present", () => {
+    const state = reducer(init(), { type: removedTask.rejected.type });
+    expect(state.error).toBe("Something went wrong");
+  });
+  it("pending clears a prior error so an identical repeat failure re-fires", () => {
+    const failed = reducer(init(), {
+      type: removedAllTask.rejected.type,
+      payload: "boom",
+    });
+    expect(failed.error).toBe("boom");
+    const retrying = reducer(failed, { type: removedAllTask.pending.type });
+    expect(retrying.error).toBe(null);
+  });
+  it("clearTaskError resets error to null", () => {
+    const state = reducer({ ...init(), error: "x" }, clearTaskError());
+    expect(state.error).toBe(null);
   });
 });

--- a/frontend/src/components/pages/ui/TaskErrorToast.jsx
+++ b/frontend/src/components/pages/ui/TaskErrorToast.jsx
@@ -2,13 +2,13 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { clearTaskError } from "../../../redux/taskSlice";
 
-// Surfaces task mutation failures (#21 / P4 #2). Reads state.task.error — which the
+// Surfaces task mutation failures (#21 / P4 #2). Reads state.tasks.error — which the
 // rejected matcher in taskSlice sets — and auto-dismisses. Mounted once at App level.
 // Self-rolled (no toast dependency); reuses the bg-purpleMain styling idiom.
 const AUTO_DISMISS_MS = 4000;
 
 const TaskErrorToast = () => {
-  const error = useSelector((state) => state.task.error);
+  const error = useSelector((state) => state.tasks.error);
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/frontend/src/components/pages/ui/TaskErrorToast.jsx
+++ b/frontend/src/components/pages/ui/TaskErrorToast.jsx
@@ -1,0 +1,55 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { clearTaskError } from "../../../redux/taskSlice";
+
+// Surfaces task mutation failures (#21 / P4 #2). Reads state.task.error — which the
+// rejected matcher in taskSlice sets — and auto-dismisses. Mounted once at App level.
+// Self-rolled (no toast dependency); reuses the bg-purpleMain styling idiom.
+const AUTO_DISMISS_MS = 4000;
+
+const TaskErrorToast = () => {
+  const error = useSelector((state) => state.task.error);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!error) return;
+    const id = setTimeout(() => dispatch(clearTaskError()), AUTO_DISMISS_MS);
+    return () => clearTimeout(id);
+  }, [error, dispatch]);
+
+  if (!error) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="fixed bottom-4 right-4 z-50 max-w-sm rounded-lg bg-purpleMain text-white shadow-lg p-4 flex items-start gap-3"
+    >
+      <svg
+        className="h-6 w-6 flex-shrink-0 text-amber-400"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+        />
+      </svg>
+      <p className="text-sm flex-1">{String(error)}</p>
+      <button
+        type="button"
+        onClick={() => dispatch(clearTaskError())}
+        aria-label="Dismiss"
+        className="text-gray-300 hover:text-white text-lg leading-none"
+      >
+        ×
+      </button>
+    </div>
+  );
+};
+
+export default TaskErrorToast;

--- a/frontend/src/redux/taskSlice.jsx
+++ b/frontend/src/redux/taskSlice.jsx
@@ -1,4 +1,9 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import {
+  createAsyncThunk,
+  createSlice,
+  isPending,
+  isRejected,
+} from "@reduxjs/toolkit";
 import { getCategoryData, removeCategory } from "../functions/category";
 
 import {
@@ -204,6 +209,9 @@ const taskSlice = createSlice({
     clearTask(state) {
       state.tasks = [];
     },
+    clearTaskError(state) {
+      state.error = null;
+    },
     clearSearchResults(state) {
       state.searchResults = [];
     },
@@ -394,7 +402,37 @@ const taskSlice = createSlice({
       })
       .addCase(removedCategory.fulfilled, (state) => {
         state.lastStateUpdate = new Date().toISOString();
-      });
+      })
+      // P4 #2 / #21 — surface mutation failures (these thunks reject without a
+      // dedicated .rejected case, so state.error was never set). One matcher per
+      // phase covers all five. Clearing on pending means an identical error string
+      // on a retry is still a fresh transition, so the toast re-fires (see #21).
+      .addMatcher(
+        isPending(
+          updatedTask,
+          completedTask,
+          removedTask,
+          removedAllTask,
+          removedCategory
+        ),
+        (state) => {
+          state.error = null;
+        }
+      )
+      .addMatcher(
+        isRejected(
+          updatedTask,
+          completedTask,
+          removedTask,
+          removedAllTask,
+          removedCategory
+        ),
+        (state, action) => {
+          // rejectWithValue lands in payload; an uncaught throw lands in error.
+          state.error =
+            action.payload ?? action.error?.message ?? "Something went wrong";
+        }
+      );
   },
 });
 
@@ -405,6 +443,7 @@ export const {
   setStreakStatus,
   toggleCreatePopup,
   clearTask,
+  clearTaskError,
   clearSearchResults,
   resetFormTask,
   addSteps,


### PR DESCRIPTION
## Problem
The 5 task mutation thunks (`updatedTask`, `completedTask`, `removedTask`, `removedAllTask`, `removedCategory`) had no `.rejected` handler, so `state.task.error` was never set — and nothing read it anyway. Failures were caught at the call sites but only `console.error`'d, so users never saw save/delete failures (#21 + P4 #2, bundled per the dead error/loading read-side).

## Approach (post-`/scrutinize`)
The scrutiny found these thunks **already** dispatch `.rejected` on a thrown payload-creator (promise rejection — `rejectWithValue` isn't required for that). So instead of 10 edits to the protected slice (5× try/catch + 5× `.rejected`), the fix is **two matchers**:

```js
.addMatcher(isPending(...5),  (s) => { s.error = null; })
.addMatcher(isRejected(...5), (s, a) => { s.error = a.payload ?? a.error?.message ?? "Something went wrong"; })
```

Clearing on `pending` means an identical repeat error is still a fresh state transition, so the toast re-fires (a real bug the naive plan would have shipped). Plus a `clearTaskError` reducer and a self-rolled, App-level `TaskErrorToast` (no new dependency, auto-dismiss 4s, reuses the `bg-purpleMain` idiom).

## Scope notes
- `loading` (#21's other half) left dead — no spinner wired yet; deferred by decision.
- Optimistic category-delete-without-rollback spun off to **BL #26** (the toast now surfaces a failure while the item has already vanished from the UI).

## Tests
**83/83 Vitest** (+5: rejectWithValue payload, error.message fallback, generic fallback, clear-on-pending re-fire, `clearTaskError`). Lint clean on touched files.

## Outstanding
Runtime `/verify` — force a 500 on a PUT/DELETE and confirm the toast renders + auto-dismisses. Not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)