### PR TITLE
fix(frontend): BL #17 — fix stale-closure clobber in TaskDetail sync effect

### DIFF
--- a/frontend/src/__tests__/components/TaskDetail.test.jsx
+++ b/frontend/src/__tests__/components/TaskDetail.test.jsx
@@ -1,0 +1,99 @@
+/* eslint-disable react/prop-types, react/display-name */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+
+// Stub all child UI components — we only care about the effect / state behaviour
+vi.mock("../../components/pages/ui/inputField", () => ({
+  default: ({ value, onChange, name }) => (
+    <input data-testid={`input-${name}`} value={value} onChange={onChange} />
+  ),
+}));
+vi.mock("../../components/pages/ui/StartDatePicker", () => ({ default: () => null }));
+vi.mock("../../components/pages/ui/DeadlinePicker",  () => ({ default: () => null }));
+vi.mock("../../components/pages/ui/ProgressField",   () => ({ default: () => null }));
+vi.mock("../../components/pages/ui/CategoryTagField",() => ({ default: () => null }));
+vi.mock("../../components/pages/ui/PriorityField",   () => ({ default: () => null }));
+vi.mock("../../components/pages/animation/FadeUpContainer", () => ({
+  default: ({ children }) => <>{children}</>,
+}));
+
+// Stub lodash debounce → no-op so the async save path never fires
+vi.mock("lodash", () => ({
+  debounce: () => {
+    const fn = vi.fn();
+    fn.flush = vi.fn();
+    return fn;
+  },
+}));
+
+import TaskDetail from "../../components/pages/ui/taskDetail";
+
+const SET_SELECTED = "TEST/setSelectedTask";
+
+function makeStore(initialTask) {
+  return configureStore({
+    reducer: {
+      tasks: (
+        state = { selectedTask: initialTask, categories: [] },
+        action
+      ) => {
+        if (action.type === SET_SELECTED) {
+          return { ...state, selectedTask: action.payload };
+        }
+        return state;
+      },
+    },
+  });
+}
+
+describe("TaskDetail — BL #17 stale-closure regression", () => {
+  it("does NOT reset editedTask when selectedTask content changes with the same _id", () => {
+    const store = makeStore({ _id: "task-1", title: "Original", note: "" });
+
+    render(
+      <Provider store={store}>
+        <TaskDetail onClose={() => {}} />
+      </Provider>
+    );
+
+    expect(screen.getByTestId("input-title").value).toBe("Original");
+
+    // User edits the title locally
+    fireEvent.change(screen.getByTestId("input-title"), {
+      target: { name: "title", value: "User edited" },
+    });
+    expect(screen.getByTestId("input-title").value).toBe("User edited");
+
+    // Simulate updatedTask.fulfilled writing server response back into selectedTask
+    // (same _id, content differs — the exact scenario that caused the stale-closure clobber)
+    act(() => {
+      store.dispatch({ type: SET_SELECTED, payload: { _id: "task-1", title: "From server", note: "" } });
+    });
+
+    // Fix: dep is selectedTask?._id — same ID means effect does not fire → local edit preserved
+    expect(screen.getByTestId("input-title").value).toBe("User edited");
+  });
+
+  it("DOES reset editedTask when a different task is opened (ID changes)", () => {
+    const store = makeStore({ _id: "task-1", title: "Task one", note: "" });
+
+    render(
+      <Provider store={store}>
+        <TaskDetail onClose={() => {}} />
+      </Provider>
+    );
+
+    fireEvent.change(screen.getByTestId("input-title"), {
+      target: { name: "title", value: "User edited" },
+    });
+
+    act(() => {
+      store.dispatch({ type: SET_SELECTED, payload: { _id: "task-2", title: "Task two", note: "" } });
+    });
+
+    // ID changed → effect fires → reset to new task
+    expect(screen.getByTestId("input-title").value).toBe("Task two");
+  });
+});

--- a/frontend/src/components/pages/ui/taskDetail.jsx
+++ b/frontend/src/components/pages/ui/taskDetail.jsx
@@ -52,7 +52,7 @@ function TaskDetail({ onClose }) {
     if (!isUpdating && selectedTask) {
       setEditedTask(selectedTask);
     }
-  }, [selectedTask]);
+  }, [selectedTask?._id]);
 
   useEffect(() => {
     return () => {
@@ -78,8 +78,6 @@ function TaskDetail({ onClose }) {
           }
         } else {
           updatedTask[name] = updatedValue;
-          console.log(value);
-          console.log(updatedValue);
         }
         debouncedUpdateTask(updatedTask);
         return updatedTask;


### PR DESCRIPTION
## Summary

`taskDetail.jsx:51-55` had a `useEffect` that guards on `isUpdating` but omits it from deps — a stale closure where `isUpdating` always reads `false` inside the effect regardless of actual save state.

**The race that fires the bug:**
1. User edits field → 500ms debounce → `setIsUpdating(true)` → dispatch save
2. `updatedTask.fulfilled` → Redux writes server response back into `selectedTask`
3. `useEffect([selectedTask])` fires; reads stale `isUpdating = false` → `setEditedTask(selectedTask)` clobbers any keystrokes typed during debounce + RTT window

**Fix:** Change dep from `[selectedTask]` to `[selectedTask?._id]`. Syncs local state only when a *different* task is opened — same-ID content changes (our own saves returning) no longer trigger a reset. The `isUpdating` guard is no longer needed for this purpose.

Also strips two leftover `console.log` calls in `handleInputChange` (BL #9).

## Test plan

- [ ] 87/87 unit tests pass (2 new regression tests added)
- [ ] **Regression 1:** `selectedTask` content changes with same `_id` → `editedTask` NOT reset
- [ ] **Regression 2:** `selectedTask._id` changes → `editedTask` IS reset to new task

🤖 Generated with [Claude Code](https://claude.com/claude-code)