### PR TITLE
fix(frontend): BL #9 — strip remaining debug console.log calls

### DIFF
--- a/frontend/src/components/pages/create/CreateEntity.jsx
+++ b/frontend/src/components/pages/create/CreateEntity.jsx
@@ -50,7 +50,6 @@ function CreateEntity({ onAddItem, entityType, onClose }) {
         }
 
         if (response) {
-          console.log("Successfully created:", response);
           setShowPopup(true);
           await new Promise((res) => setTimeout(res, 700));
           setShowPopup(false);

--- a/frontend/src/components/pages/fixbar/GroupTaskForm.jsx
+++ b/frontend/src/components/pages/fixbar/GroupTaskForm.jsx
@@ -38,7 +38,6 @@ function GroupTaskForm({ filter }) {
           const keys = `
             ${group.categoryId || group.status || group.deadlineCase}-${index}`;
           const tasks = group.tasks || [];
-          console.log("Fetched Tasks:", tasks);
 
           return (
             <div

--- a/frontend/src/components/pages/hooks/usePopup.jsx
+++ b/frontend/src/components/pages/hooks/usePopup.jsx
@@ -37,7 +37,6 @@ function usePopup() {
   };
 
   const handleTaskClick = (task) => {
-    console.log("Task clicked:", task);
     dispatch(setSelectedTask(task));
   };
 

--- a/frontend/src/components/pages/user/Settings.jsx
+++ b/frontend/src/components/pages/user/Settings.jsx
@@ -80,7 +80,6 @@ function Settings() {
     );
   }
 
-  console.log('settings status isAuthenticate:', isAuthenticated);
   return (
     <div
       id="otherPage"

--- a/frontend/src/redux/userSlice.jsx
+++ b/frontend/src/redux/userSlice.jsx
@@ -49,9 +49,6 @@ export const loginUser = createAsyncThunk(
   async (userInput, { rejectWithValue }) => {
     try {
       const response = await minimumLoading(userLogin(userInput));
-      if(response){
-        console.log('login response from redux :',response)
-      }
       return { user: response.user };
     } catch (error) {
       return rejectWithValue(error.message);


### PR DESCRIPTION
## Summary

Removes the final 5 write-only debug `console.log` calls identified in BL #9:

| File | Line | Log removed |
|------|------|-------------|
| `redux/userSlice.jsx` | 53 | login response dump (leaks auth data to console) |
| `pages/create/CreateEntity.jsx` | 53 | created entity response |
| `pages/fixbar/GroupTaskForm.jsx` | 41 | fetched tasks list |
| `pages/hooks/usePopup.jsx` | 40 | task clicked |
| `pages/user/Settings.jsx` | 83 | auth status on every render |

Protected files left unchanged: `axiosConfig.js` (interceptor diagnostics) and `CreateTask.jsx` (own phase, BL #20/#24).

BL #9 is now fully closed.

## Test plan

- [ ] 87/87 tests pass — no behaviour change, logs were write-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)