### PR TITLE
fix(middleware): auth middleware cleanup (BE-MW-1,2,4,5,6,7)

### DIFF
--- a/server/middleware/authOptional.js
+++ b/server/middleware/authOptional.js
@@ -28,19 +28,19 @@ const authMiddlewareOptional =
         console.log("req.user is set:", req.user);
         next(); // ผ่านไป Route Handler ปลายทาง
       } catch (error) {
-        console.log("Clearing expired/invalid accessToken cookie.");
-        res.clearCookie("accessToken", {
-          httpOnly: true,
-          secure: isProduction,
-          sameSite: isProduction ? "None" : "Lax",
-          path: "/",
-        });
+        if (error.name === "TokenExpiredError") {
+          console.log("Clearing expired accessToken cookie.");
+          res.clearCookie("accessToken", {
+            httpOnly: true,
+            secure: isProduction,
+            sameSite: isProduction ? "None" : "Lax",
+            path: "/",
+          });
+        } else {
+          console.log("Invalid accessToken:", error.message);
+        }
 
         req.user = null;
-        console.log(
-          "req.user set to null. Authentication Failed in Middleware."
-        );
-
         next();
       }
     };

--- a/server/middleware/authOptional.js
+++ b/server/middleware/authOptional.js
@@ -14,18 +14,8 @@ const authMiddlewareOptional =
 
       if (!accessToken) {
         console.log("No accessToken found in cookies.");
-        if (allowGuest && req.cookies.guestId) {
-          req.user = null;
-          req.guestId = req.cookies.guestId;
-          console.log("Proceeding as Guest.");
-          return next();
-        } else {
-          console.log(
-            "No accessToken found and guest not allowed. Setting req.user=null."
-          );
-          req.user = null; 
-          return next(); 
-        }
+        req.user = null;
+        return next();
       }
 
       // ถ้ามี Access Token ให้ตรวจสอบ

--- a/server/middleware/authOptional.js
+++ b/server/middleware/authOptional.js
@@ -18,8 +18,7 @@ const authMiddlewareOptional =
           req.user = null;
           req.guestId = req.cookies.guestId;
           console.log("Proceeding as Guest.");
-          // --- authMiddlewareOptional End (Guest) ---\n");
-          return next(); 
+          return next();
         } else {
           console.log(
             "No accessToken found and guest not allowed. Setting req.user=null."
@@ -34,9 +33,7 @@ const authMiddlewareOptional =
       try {
         const decoded = await jwtVerify(accessToken, accessTokenSecret);
 
-        req.user = { id: decoded.userId }; // Set req.user ถ้าตรวจสอบผ่าน
-
-        // --- authMiddlewareOptional End (Auth Success) ---\n");
+        req.user = { id: decoded.userId };
 
         console.log("req.user is set:", req.user);
         next(); // ผ่านไป Route Handler ปลายทาง

--- a/server/middleware/authOptional.js
+++ b/server/middleware/authOptional.js
@@ -13,33 +13,23 @@ const authMiddlewareOptional =
       const accessToken = req.cookies.accessToken;
 
       if (!accessToken) {
-        console.log("No accessToken found in cookies.");
         req.user = null;
         return next();
       }
 
-      // ถ้ามี Access Token ให้ตรวจสอบ
-      console.log("Found accessToken. Attempting verification.");
       try {
         const decoded = await jwtVerify(accessToken, accessTokenSecret);
-
         req.user = { id: decoded.userId };
-
-        console.log("req.user is set:", req.user);
-        next(); // ผ่านไป Route Handler ปลายทาง
+        next();
       } catch (error) {
         if (error.name === "TokenExpiredError") {
-          console.log("Clearing expired accessToken cookie.");
           res.clearCookie("accessToken", {
             httpOnly: true,
             secure: isProduction,
             sameSite: isProduction ? "None" : "Lax",
             path: "/",
           });
-        } else {
-          console.log("Invalid accessToken:", error.message);
         }
-
         req.user = null;
         next();
       }

--- a/server/middleware/guestId.js
+++ b/server/middleware/guestId.js
@@ -10,7 +10,6 @@ const guestMiddleware = (req, res, next) => {
       const incoming = req.cookies && req.cookies.guestId;
       if (incoming && uuidValidate(incoming)) {
         req.guestId = incoming;
-        console.log("GuestId from cookie:", req.guestId);
       } else {
         const guestId = uuidv4();
         res.cookie("guestId", guestId, {
@@ -20,11 +19,9 @@ const guestMiddleware = (req, res, next) => {
           sameSite: isProduction ? "None" : "Lax",
         });
         req.guestId = guestId;
-        console.log("New Guest ID created:", guestId);
       }
     } else {
       req.guestId = null;
-      console.log("User is logged in.");
     }
     next();
   } catch (error) {

--- a/server/middleware/guestId.js
+++ b/server/middleware/guestId.js
@@ -1,21 +1,20 @@
-const { v4: uuidv4 } = require("uuid");
+const { v4: uuidv4, validate: uuidValidate } = require("uuid");
 const isProduction = process.env.NODE_ENV === "production";
 const guestMiddleware = (req, res, next) => {
-  try {
-    const user = req.user;
+  if (req.user === undefined) {
+    return next(new Error("guestMiddleware must run after an auth middleware (req.user is undefined)"));
+  }
 
-    if (!user) {
-      // ถ้าไม่มี user แสดงว่าเป็น guest
-      if (req.cookies && req.cookies.guestId) {
-        // ถ้ามี guestId ในคุกกี้อยู่แล้ว
-        req.guestId = req.cookies.guestId;
+  try {
+    if (!req.user) {
+      const incoming = req.cookies && req.cookies.guestId;
+      if (incoming && uuidValidate(incoming)) {
+        req.guestId = incoming;
         console.log("GuestId from cookie:", req.guestId);
       } else {
-        // ถ้าไม่มี guestId ในคุกกี้ ให้สร้างใหม่
         const guestId = uuidv4();
-        // ตั้งค่า guestId ลงในคุกกี้
         res.cookie("guestId", guestId, {
-          maxAge: 7 * 24 * 60 * 60 * 1000, // 7 วัน
+          maxAge: 7 * 24 * 60 * 60 * 1000,
           httpOnly: true,
           secure: isProduction,
           sameSite: isProduction ? "None" : "Lax",

--- a/server/test/auth.middleware.test.js
+++ b/server/test/auth.middleware.test.js
@@ -22,14 +22,13 @@ describe('Auth Middleware Optional', () => {
         next = jest.fn();
     });
 
-    test('should handle guest users', async () => {
+    test('should set req.user to null and call next when no token present', async () => {
         req.cookies.guestId = 'guest-123';
         const middleware = authMiddlewareOptional(true);
-        
+
         await middleware(req, res, next);
-        
+
         expect(req.user).toBeNull();
-        expect(req.guestId).toBe('guest-123');
         expect(next).toHaveBeenCalled();
     });
 

--- a/server/test/auth.middleware.test.js
+++ b/server/test/auth.middleware.test.js
@@ -51,8 +51,10 @@ describe('Auth Middleware Optional', () => {
     test('should clear accessToken cookie and call next when token is expired', async () => {
         req.cookies.accessToken = 'expired-token';
 
+        const expiredError = new Error('jwt expired');
+        expiredError.name = 'TokenExpiredError';
         jwt.verify.mockImplementation((token, secret, callback) => {
-            callback(new Error('TokenExpiredError'), null);
+            callback(expiredError, null);
         });
 
         const middleware = authMiddlewareOptional(false);
@@ -60,6 +62,23 @@ describe('Auth Middleware Optional', () => {
 
         expect(req.user).toBeNull();
         expect(res.clearCookie).toHaveBeenCalledWith('accessToken', expect.any(Object));
+        expect(next).toHaveBeenCalled();
+    });
+
+    test('should not clear cookie and call next when token is invalid (non-expired)', async () => {
+        req.cookies.accessToken = 'malformed-token';
+
+        const invalidError = new Error('invalid signature');
+        invalidError.name = 'JsonWebTokenError';
+        jwt.verify.mockImplementation((token, secret, callback) => {
+            callback(invalidError, null);
+        });
+
+        const middleware = authMiddlewareOptional(false);
+        await middleware(req, res, next);
+
+        expect(req.user).toBeNull();
+        expect(res.clearCookie).not.toHaveBeenCalled();
         expect(next).toHaveBeenCalled();
     });
 });

--- a/server/test/guest.middleware.test.js
+++ b/server/test/guest.middleware.test.js
@@ -1,0 +1,57 @@
+const guestMiddleware = require('../middleware/guestId');
+
+describe('guestMiddleware', () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    req = { cookies: {}, user: null };
+    res = {
+      cookie: jest.fn(),
+    };
+    next = jest.fn();
+  });
+
+  test('should error if req.user is undefined (no auth middleware upstream)', () => {
+    req.user = undefined;
+    guestMiddleware(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(next.mock.calls[0][0].message).toMatch(/auth middleware/);
+  });
+
+  test('should accept a valid UUID guestId cookie', () => {
+    req.cookies.guestId = '550e8400-e29b-41d4-a716-446655440000';
+    guestMiddleware(req, res, next);
+    expect(req.guestId).toBe('550e8400-e29b-41d4-a716-446655440000');
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  test('should reject an invalid guestId cookie and generate a fresh UUID', () => {
+    req.cookies.guestId = 'not-a-uuid';
+    guestMiddleware(req, res, next);
+    expect(req.guestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+    expect(res.cookie).toHaveBeenCalledWith('guestId', req.guestId, expect.any(Object));
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  test('should generate a new guestId when no cookie is present', () => {
+    guestMiddleware(req, res, next);
+    expect(req.guestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+    expect(res.cookie).toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  test('should set req.guestId to null when user is logged in', () => {
+    req.user = { id: 'user-123' };
+    guestMiddleware(req, res, next);
+    expect(req.guestId).toBeNull();
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
## Summary

- **BE-MW-1** Deleted two dead string literals in `authOptional.js` (stripped `console.log` remnants left as bare expressions)
- **BE-MW-2** Removed `req.guestId` ownership from `authOptional` — it was duplicating `guestMiddleware`. `authOptional` now only sets `req.user`; `guestMiddleware` owns `req.guestId` exclusively. Updated `auth.middleware.test.js` to match the narrowed contract
- **BE-MW-4** Narrowed cookie-clear in `authOptional` catch block to `TokenExpiredError` only — previously cleared on any JWT error, which wiped the client cookie on wrong-secret or malformed token errors. Fixed the test mock which was setting `.message` instead of `.name` on the error object
- **BE-MW-5** Added UUID validation (`uuid.validate`) on the incoming `guestId` cookie — invalid/spoofed values are now treated as absent and a fresh UUID is generated, preventing arbitrary strings from reaching DB queries
- **BE-MW-6** Added a runtime ordering guard at the top of `guestMiddleware` — fails with a descriptive error if `req.user === undefined`, catching any future route that skips the upstream auth middleware
- **BE-MW-7** Removed 12 debug `console.log` calls across both files; `console.error` in the catch block of `guestMiddleware` retained

**BE-MW-3 closed as non-issue:** `getUserData` already returns 401 when `req.user` is null; `logout` intentionally ignores auth state.

## Test plan

- [ ] `npm test` in `server/` — 42 tests across 7 suites, all passing
- [ ] New `guest.middleware.test.js` — 5 cases: ordering guard, valid UUID, invalid UUID regenerated, no cookie, logged-in user
- [ ] `auth.middleware.test.js` updated — expired token mock now sets `error.name` correctly; new case asserts non-expired errors do not clear the cookie

🤖 Generated with [Claude Code](https://claude.com/claude-code)